### PR TITLE
fix 'expected BEGIN_OBJECT but was BEGIN_ARRAY' on staff & donors endpoints

### DIFF
--- a/src/main/java/net/laboulangerie/api/database/GsonFiles.java
+++ b/src/main/java/net/laboulangerie/api/database/GsonFiles.java
@@ -27,7 +27,7 @@ public class GsonFiles {
         }
 
         return new Gson().fromJson(new FileReader(file),
-                new com.google.gson.reflect.TypeToken<TypedNameIdModel>() {
+                new com.google.gson.reflect.TypeToken<TypedNameIdModel[]>() {
                 }.getType());
     }
 


### PR DESCRIPTION
```
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:397)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1227)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1137)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1107)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.database.GsonFiles.readArray(GsonFiles.java:29)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.controllers.StaffController.getStaffArray(StaffController.java:34)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.controllers.StaffController.getStaff(StaffController.java:48)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.routing.HandlerEntry.handle(HandlerEntry.kt:19)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.DefaultTasks.HTTP$lambda-8$lambda-6$lambda-5$lambda-4$lambda-3(DefaultTasks.kt:32)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.handleTask(JavalinServlet.kt:86)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.handleSync(JavalinServlet.kt:53)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.service(JavalinServlet.kt:41)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.jetty.JavalinJettyServlet.service(JavalinJettyServlet.kt:58)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:529)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1571)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.jetty.JettyServer$start$wsAndHttpHandler$1.doHandle(JettyServer.kt:57)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1544)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1302)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:173)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.Server.handle(Server.java:563)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.lambda$handle$0(HttpChannel.java:505)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:762)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:497)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:282)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:393)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:386)
[18:13:58] [JettyServerThreadPool-Virtual-750/WARN]: 	... 39 more
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:397)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1227)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1137)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.Gson.fromJson(Gson.java:1107)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.database.GsonFiles.readArray(GsonFiles.java:29)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.controllers.DonorsController.getDonorsArray(DonorsController.java:32)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//net.laboulangerie.api.controllers.DonorsController.getDonors(DonorsController.java:46)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.routing.HandlerEntry.handle(HandlerEntry.kt:19)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.DefaultTasks.HTTP$lambda-8$lambda-6$lambda-5$lambda-4$lambda-3(DefaultTasks.kt:32)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.handleTask(JavalinServlet.kt:86)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.handleSync(JavalinServlet.kt:53)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.http.servlet.JavalinServlet.service(JavalinServlet.kt:41)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.jetty.JavalinJettyServlet.service(JavalinJettyServlet.kt:58)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:529)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1571)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//io.javalin.jetty.JettyServer$start$wsAndHttpHandler$1.doHandle(JettyServer.kt:57)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1544)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1302)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:173)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.Server.handle(Server.java:563)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.lambda$handle$0(HttpChannel.java:505)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:762)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:497)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:282)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at LaBoulangerieAPI.jar//org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:393)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:386)
[18:13:58] [JettyServerThreadPool-Virtual-751/WARN]: 	... 39 more
```